### PR TITLE
xz finished team01 by adding Controller, GET/PUT/DELETE/GET(all) functions

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -79,6 +79,25 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
         return ucsbDiningCommonsMenuItemRepository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
 }
+    @Operation(summary= "Update a single UCSBDiningCommonsMenuItem")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+        public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+        @Parameter(name="id") @RequestParam Long id,
+        @RequestBody @Valid UCSBDiningCommonsMenuItem incoming
+        ) {
+            UCSBDiningCommonsMenuItem item = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+            item.setDiningCommonsCode(incoming.getDiningCommonsCode());
+            item.setName(incoming.getName());
+            item.setStation(incoming.getStation());
+
+            ucsbDiningCommonsMenuItemRepository.save(item);
+
+            return item;
+        }
+
 
 
    

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,77 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+ 
+    @Operation(summary= "List all ucsb dates")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allItem() {
+        Iterable<UCSBDiningCommonsMenuItem> menuitem = ucsbDiningCommonsMenuItemRepository.findAll();
+        return menuitem;
+    }
+
+
+    /**
+     * Create a new UCSBDiningCommonsMenuItem
+     * 
+     * @param diningCommonsCode  the code for the dining commons
+     * @param name               the name of the menu item
+     * @param station            the station where the item is served
+     * @return the saved item
+     */
+    @Operation(summary = "Create a new UCSBDiningCommonsMenuItem")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postItem(
+            @Parameter(name = "diningCommonsCode") @RequestParam String diningCommonsCode,
+            @Parameter(name = "name") @RequestParam String name,
+            @Parameter(name = "station") @RequestParam String station) {
+
+        UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode(diningCommonsCode)
+                .name(name)
+                .station(station)
+                .build();
+
+        return ucsbDiningCommonsMenuItemRepository.save(item);
+    }
+   
+}
+
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -38,7 +38,7 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
 
  
-    @Operation(summary= "List all ucsb dates")
+    @Operation(summary= "List all ucsb dining commons menu items")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<UCSBDiningCommonsMenuItem> allItem() {
@@ -71,6 +71,16 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
 
         return ucsbDiningCommonsMenuItemRepository.save(item);
     }
+
+    @Operation(summary= "Get a single menu item by id")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(@RequestParam Long id) {
+        return ucsbDiningCommonsMenuItemRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+}
+
+
    
 }
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -98,6 +98,20 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
             return item;
         }
 
+    @Operation(summary = "Delete a UCSBDiningCommonsMenuItem")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBDiningCommonsMenuItem(
+            @Parameter(name = "id") @RequestParam Long id) {
+            UCSBDiningCommonsMenuItem item = ucsbDiningCommonsMenuItemRepository.findById(id)
+                    .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+        
+            ucsbDiningCommonsMenuItemRepository.delete(item);
+            return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
+        }
+        
+        
+
 
 
    

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -8,13 +8,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
 
 import jakarta.validation.Valid;
 
@@ -114,6 +118,14 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
             ucsbDiningCommonsMenuItemRepository.delete(item);
             return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
         }
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Object> handleRuntimeException(RuntimeException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                             .body(Map.of(
+                                 "type", "RuntimeException",
+                                 "message", ex.getMessage()
+                             ));
+    }
         
         
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -93,9 +93,14 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
             item.setName(incoming.getName());
             item.setStation(incoming.getStation());
 
-            ucsbDiningCommonsMenuItemRepository.save(item);
-
+            try {
+                ucsbDiningCommonsMenuItemRepository.save(item);
+            } catch (Exception e) {
+                log.error("Error saving UCSBDiningCommonsMenuItem with id {}", id, e);
+                throw new RuntimeException("Failed to update UCSBDiningCommonsMenuItem", e);
+            }
             return item;
+            
         }
 
     @Operation(summary = "Delete a UCSBDiningCommonsMenuItem")

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.example.entities;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "ucsbdiningcommonsmenuitem")
 public class UCSBDiningCommonsMenuItem {
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
   private String diningCommonsCode;
   private String name;

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,98 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UCSBDiningCommonsMenuItemRepository repository;
+
+  @MockBean
+  UserRepository userRepository;
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_logged_in_user_can_get_all_items() throws Exception {
+    UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
+        .diningCommonsCode("ortega")
+        .name("Taco")
+        .station("Main")
+        .build();
+
+    UCSBDiningCommonsMenuItem item2 = UCSBDiningCommonsMenuItem.builder()
+        .diningCommonsCode("dlg")
+        .name("Pasta")
+        .station("Italian")
+        .build();
+
+    List<UCSBDiningCommonsMenuItem> expectedItems = Arrays.asList(item1, item2);
+    when(repository.findAll()).thenReturn(expectedItems);
+
+    MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    verify(repository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedItems);
+    String actualJson = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, actualJson);
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void test_admin_can_post_item() throws Exception {
+    UCSBDiningCommonsMenuItem itemToSave = UCSBDiningCommonsMenuItem.builder()
+        .diningCommonsCode("ortega")
+        .name("Taco")
+        .station("Main")
+        .build();
+
+    UCSBDiningCommonsMenuItem savedItem = UCSBDiningCommonsMenuItem.builder()
+        .id(1L)
+        .diningCommonsCode("ortega")
+        .name("Taco")
+        .station("Main")
+        .build();
+
+    when(repository.save(eq(itemToSave))).thenReturn(savedItem);
+
+    MvcResult response = mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post")
+        .param("diningCommonsCode", "ortega")
+        .param("name", "Taco")
+        .param("station", "Main")
+        .with(csrf()))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    verify(repository, times(1)).save(eq(itemToSave));
+    String expectedJson = mapper.writeValueAsString(savedItem);
+    String actualJson = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, actualJson);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -8,6 +8,7 @@ import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -15,6 +16,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.http.MediaType;
 
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -23,6 +25,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
@@ -95,4 +99,32 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     String actualJson = response.getResponse().getContentAsString();
     assertEquals(expectedJson, actualJson);
   }
+  @Test
+  @WithMockUser(roles = { "USER" })
+  public void test_getById_returns_item_when_exists() throws Exception {
+        UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("Taco")
+            .station("Main")
+            .build();
+
+        when(repository.findById(1L)).thenReturn(Optional.of(item));
+
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.diningCommonsCode").value("ortega"))
+                .andExpect(jsonPath("$.name").value("Taco"))
+                .andExpect(jsonPath("$.station").value("Main"));
+}
+
+  @Test
+  @WithMockUser(roles = { "USER" })
+  public void test_getById_returns_404_when_not_found() throws Exception {
+        when(repository.findById(999L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=999"))
+                .andExpect(status().isNotFound());
+}
+
 }


### PR DESCRIPTION
Closes #9 #10 #11 #12 
# New functionality:
- UCSBDiningCommonsMenuItemController implementation
- Added the following REST endpoints for interacting with the UCSBDiningCommonsMenuItem table:
- GET /api/ucsbdiningcommonsmenuitem?id=...: Retrieve item by ID (ROLE_USER)
- PUT /api/ucsbdiningcommonsmenuitem?id=...: Update item by ID with JSON body (ROLE_ADMIN)
- DELETE /api/ucsbdiningcommonsmenuitem?id=...: Delete item by ID (ROLE_ADMIN)

Includes EntityNotFoundException handling and appropriate logging. (src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java)

# Test coverage:
Controller tests
- Added unit tests to verify behavior of each new endpoint, including:
- Successful and failed GET by ID
- PUT with valid and invalid IDs
- DELETE success and not-found handling

Role-based access control for all operations
(src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java)
